### PR TITLE
Fix evaluation with new gymnasium API

### DIFF
--- a/HW2/task2_CryptoTradingAgent/trading_agent.py
+++ b/HW2/task2_CryptoTradingAgent/trading_agent.py
@@ -152,13 +152,14 @@ class TradingAgent:
         """
         episode_rewards = []
         for _ in range(n_episodes):
-            obs = env.reset()
+            obs, _ = env.reset()
             done = False
             episode_reward = 0
-            
+
             while not done:
                 action, _ = self.predict(obs)
-                obs, reward, done, _ = env.step(action)
+                obs, reward, terminated, truncated, _ = env.step(action)
+                done = terminated or truncated
                 episode_reward += reward
             
             episode_rewards.append(episode_reward)


### PR DESCRIPTION
## Summary
- update trading agent evaluation to handle gymnasium's reset/step API

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683fe64c46f8832c92e22e5d5ac94143